### PR TITLE
TypeError in `address_masker` when processing addresses with `lok` abbreviation

### DIFF
--- a/priv_masker/masks/address_masker.py
+++ b/priv_masker/masks/address_masker.py
@@ -54,7 +54,7 @@ class AddressMasker(Masker):
         for match_id, start, end in apartment_numbers_matches:
             span = doc[start:end]
             if span[0].i in address_number_matches_ends:
-                masked_tokens = masked_tokens.append(doc[end])
+                masked_tokens.append(doc[end])
 
         # wyszukiwanie liczb, które wskazują na adres:
         # gdy liczba występuje we frazie nominalnej gdzie występuje zamaskowany token wskazujący na adres, to ta liczba


### PR DESCRIPTION
## Bug description

This PR fixes a crash in the `address_masker` component of `priv_masker`, caused by incorrect usage of the Python list `.append()` method.

### Problematic line:
```python
masked_tokens = masked_tokens.append(doc[end])
```

This causes `masked_tokens` to become `None`, since `list.append()` returns `None`. As a result, any later use of `masked_tokens` (like `if token in masked_tokens`) crashes with:

```
TypeError: argument of type 'NoneType' is not iterable
```

---

## Reproduction

Minimal example (adapted from the official README):

```text
ul. Juliusza Słowackiego 13 lok 3
```

This triggers a crash in `search_address_nums_with_key_words()`.

---

## Fix

The incorrect line was replaced with:

```python
masked_tokens.append(doc[end])
```

This keeps `masked_tokens` as a valid list and prevents the crash.

---

## Why this matters

This fix restores correct functionality to address matching involving apartment indicators like `lok`, `lokal`, etc., which are common in real-world Polish addresses.

---

Pozdrowienia